### PR TITLE
fix filename typo

### DIFF
--- a/data_structures/graphs/adjacency_list.py
+++ b/data_structures/graphs/adjacency_list.py
@@ -17,7 +17,7 @@ class Graph:
         node = AdjNode(dest)
         node.next = self.graph[src]
         self.graph[src] = node
-        
+
         # Adding source node to the destination as it is an
         # undirected graph
         node = AdjNode(src)
@@ -27,7 +27,7 @@ class Graph:
 
     def print_graph(self):
         for i in range(self.V):
-            print("Adjency list of vertex {}\n head".format(i), end="")
+            print("Adjacency list of vertex {}\n head".format(i), end="")
             temp = self.graph[i]
             while temp:
                 print(" -> {}".format(temp.vertex), end="")

--- a/data_structures/graphs/index.md
+++ b/data_structures/graphs/index.md
@@ -1,3 +1,3 @@
 # Index of graphs
 
-* [Adjacency List](adjeceny_list.py)
+* [Adjacency List](adjacency_list.py)


### PR DESCRIPTION
# Description

fix filename typo of "adjacency _list.py" as well as in index.md


# Checklist:

- [x] My code follows the style guidelines of this project i.e. [Pep8](https://www.python.org/dev/peps/pep-0008/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have squashed unnecessary commits
