### PR TITLE
Bubble Sort Fix

### DIFF
--- a/algorithms/sorting/bubble_sort.py
+++ b/algorithms/sorting/bubble_sort.py
@@ -1,12 +1,18 @@
-'''
+"""
 Bubble Sort worst time complexity occurs when array is reverse sorted - O(n^2)
 Best time scenario is when array is already sorted - O(n)
-'''
+"""
+
 
 def bubble_sort(array):
-    n = len(array)
+    has_swapped = True
 
-    for i in range(n):
-        for j in range(0, n-i-1):
-            if array[j] > array[j+1]:
-                array[j], array[j+1] = array[j+1], array[j]
+    num_of_iterations = 0
+
+    while has_swapped:
+        has_swapped = False
+        for i in range(len(array) - num_of_iterations - 1):
+            if array[i] > array[i + 1]:
+                array[i], array[i + 1] = array[i + 1], array[i]
+                has_swapped = True
+        num_of_iterations += 1


### PR DESCRIPTION
# Description

The Bubble Sort description said the best case complexity is O(n), but the code did not reflect that. The best case complexity of the code was still O(n^2). I rewrote and optimized the method.

Fixes # (issue)

The best case complexity of the code was not O(n). The previous code lacked the control whether there was any swap in the inner loop, and the breaking out of the outer loop if there wasn't. That control makes it possible that the best case (an already sorted array) is O(n), since then there are no swaps in the inner loop when it runs the first time.

**timeit results:**
Previous Code: 0.006157257000000027
Optimized Code:0.0016905610000000904

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project i.e. [Pep8](https://www.python.org/dev/peps/pep-0008/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have squashed unnecessary commits
