### PR TITLE
Longest Increasing Subsequence

### DIFF
--- a/algorithms/dynamic_programming/longest_increasing_subsequence.py
+++ b/algorithms/dynamic_programming/longest_increasing_subsequence.py
@@ -1,0 +1,13 @@
+def LIS(arr):
+    n = len(arr)
+    if n == 0: return 0
+    res = 1
+    dp = [0] * n
+    dp[0] = 1
+    for i in range(1, n): 
+        dp[i] = 1; 
+        for j in range(0 , i):
+            if arr[i] > arr[j]:
+                dp[i] = max(dp[i] , dp[j] + 1)
+        res = max(res , dp[i])
+    return res


### PR DESCRIPTION
# Description

Function gets array end return length of the Longest Increasing Subsequence

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] New feature

# Checklist:

- [x] My code follows the style guidelines of this project i.e. [Pep8](https://www.python.org/dev/peps/pep-0008/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have squashed unnecessary commits
