### PR TITLE
docs: Fix a few typos

### DIFF
--- a/data_structures/array/all_numbers_divisible.py
+++ b/data_structures/array/all_numbers_divisible.py
@@ -2,7 +2,7 @@
 # in the array are divisible by it
 
 # A - just find the min in the array and check if all the other elements
-# are divisble by it
+# are divisible by it
 
 import sys
 

--- a/data_structures/array/index.md
+++ b/data_structures/array/index.md
@@ -44,7 +44,7 @@ output=[2,3]
 Find three largest numbers from an array
 * [Triplet Sum](triplet_sum.py)
 
-Find three elements of an array whose sum is eqaul to a given value
+Find three elements of an array whose sum is equal to a given value
 
 * [Moves to Zero](moves_zeros_to_end.py)
 
@@ -74,7 +74,7 @@ For a given array return an array that contains square of elements.
 Find an element in an array which has most occurences
 * [Find Sum](find_sum.py)
 
-Find if sum of any elements in array is eqaul to a given number
+Find if sum of any elements in array is equal to a given number
 * [Quick Sort](quick_sort.py)
 
 ### Implement Quick Sort algorithm

--- a/data_structures/binary_trees/children_sum_property.py
+++ b/data_structures/binary_trees/children_sum_property.py
@@ -1,4 +1,4 @@
-# Check whether a tree statisfies children sum property
+# Check whether a tree satisfies children sum property
 # Children sum property is such that every partent = left + right child
 
 class Node:

--- a/data_structures/graphs/cycle_in_directed_graph_using_colors.py
+++ b/data_structures/graphs/cycle_in_directed_graph_using_colors.py
@@ -1,6 +1,6 @@
 """
 Using three colors - white, gray and black
-White - vertices that are not processed (inital state of all vertices)
+White - vertices that are not processed (initial state of all vertices)
 Gray - vertices that are in DFS
 Black - fully traversed vertices (i.e its progenies are also done)
 

--- a/data_structures/graphs/cycle_in_directed_graph_using_colors_recursive.py
+++ b/data_structures/graphs/cycle_in_directed_graph_using_colors_recursive.py
@@ -1,6 +1,6 @@
 """
 Using three colors - white, gray and black
-White - vertices that are not processed (inital state of all vertices)
+White - vertices that are not processed (initial state of all vertices)
 Gray - vertices that are in DFS
 Black - fully traversed vertices (i.e its progenies are also done)
 

--- a/data_structures/graphs/dag_longest_path.py
+++ b/data_structures/graphs/dag_longest_path.py
@@ -1,5 +1,5 @@
 """
-The idea is similar to DAG Shortest Path. Only the comparision part changes
+The idea is similar to DAG Shortest Path. Only the comparison part changes
 """
 
 from collections import defaultdict

--- a/data_structures/heap/max_heap.py
+++ b/data_structures/heap/max_heap.py
@@ -78,7 +78,7 @@ class MaxHeap:
     def max_heapify(self, pos):
         """
         This function will run whenever a node is non-leaf
-        node and smaller than its childen
+        node and smaller than its children
         """
         if not self.is_leaf(pos):
             left = self.heap[self.left_child(pos)]

--- a/data_structures/strings/KMP_Pattern_Search.py
+++ b/data_structures/strings/KMP_Pattern_Search.py
@@ -10,7 +10,7 @@ def KMP_pattern_search(pattern, text):
     # index for pattern[]
     j=0
 
-    # preprocess the pattern (caluclate long_prefix_suffix[] array)
+    # preprocess the pattern (calculate long_prefix_suffix[] array)
     long_Prefix_Suffix_Array(pattern, P, long_prefix_suffix)
 
     # index for text[]


### PR DESCRIPTION
There are small typos in:
- data_structures/array/all_numbers_divisible.py
- data_structures/array/index.md
- data_structures/binary_trees/children_sum_property.py
- data_structures/graphs/cycle_in_directed_graph_using_colors.py
- data_structures/graphs/cycle_in_directed_graph_using_colors_recursive.py
- data_structures/graphs/dag_longest_path.py
- data_structures/heap/max_heap.py
- data_structures/strings/KMP_Pattern_Search.py

Fixes:
- Should read `initial` rather than `inital`.
- Should read `equal` rather than `eqaul`.
- Should read `satisfies` rather than `statisfies`.
- Should read `divisible` rather than `divisble`.
- Should read `comparison` rather than `comparision`.
- Should read `children` rather than `childen`.
- Should read `calculate` rather than `caluclate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md