### PR TITLE
adding an edge case missed in linked  list remove_nth_node_from_end.py

### DIFF
--- a/data_structures/linked_list/remove_nth_node_from_end.py
+++ b/data_structures/linked_list/remove_nth_node_from_end.py
@@ -6,17 +6,20 @@ class Node():
 
 
 def remove(head, n):
-    res = head
-    slow = head
-    fast = head
-
-    for i in range(n+1):
+    extra = Node(0)
+    extra.next = head
+    fast = extra
+    slow = extra
+    for _ in range(n):
         fast = fast.next
-    while fast:
+
+    while fast.next:
         fast = fast.next
         slow = slow.next
+
     slow.next = slow.next.next
-    return res
+
+    return extra.next
 
 def print_list(head):
     curr = head
@@ -30,7 +33,7 @@ head.next.next = Node(3)
 head.next.next.next = Node(4)
 head.next.next.next.next = Node(5)
 print_list(head)
-remove(head, 2)
+head = remove(head, 5)
 print_list(head)
 
 


### PR DESCRIPTION
Case when the length of the linked list and N is equal

# Description

In the Linked List Problem of Removing nth Node from the End, One of the cases was missed where the length of the linked list is equal to n, In this case, the current code throws AttributeError: 'NoneType' object has no attribute 'next'

Fixes # (issue)

1. Adding an extra node in front 
2. Return value from function remove was not assigned to head 

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)
